### PR TITLE
revert back lift-thrice macro

### DIFF
--- a/include/lift.hpp
+++ b/include/lift.hpp
@@ -28,6 +28,13 @@
         return f_of_a;                                                \
     }
 
+#define LIFT_THRICE(...)                                 \
+  noexcept(noexcept(__VA_ARGS__))->decltype(__VA_ARGS__) \
+  {                                                      \
+    return __VA_ARGS__;                                  \
+  }
+
+#define LIFT_FWD(x) std::forward<decltype(x)>(x)
 #ifndef LIFT
 #define LIFT LIFT_FUNCTION
 #endif


### PR DESCRIPTION
otherwise many funciton like negate that use this macro report error.